### PR TITLE
Updating the version of pillow to 8.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cython==0.29.1
 h5py==2.8.0
 nltk==3.4.5
 numpy==1.15.4
-Pillow==5.3.0
+Pillow==8.1.0
 pyyaml>=4.2b1
 six==1.11.0
 tensorboardX==1.2


### PR DESCRIPTION
Deprecations
FreeType 2.7
Support for FreeType 2.7 is deprecated and will be removed in Pillow 9.0.0 (2022-01-02), when FreeType 2.8 will be the minimum supported.

We recommend upgrading to at least FreeType 2.10.4, which fixed a severe vulnerability introduced in FreeType 2.6 (CVE-2020-15999).

API Additions
Append images to ICO
When saving an ICO image, the file may contain versions of the image at different sizes. By default, Pillow will scale down the main image to create these copies.

With this release, a list of images can be provided to the append_images parameter when saving, to replace the scaled down versions. This is the same functionality that already exists for the ICNS format.